### PR TITLE
docs: add documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Sistema de processamento de vídeos baseado em filas usando NestJS, AWS SQS e S3.
 
+## Documentação
+
+- [Arquitetura](docs/ARCHITECTURE.md) - Visão geral da arquitetura do sistema
+- [Desenvolvimento](docs/DEVELOPMENT.md) - Guia de desenvolvimento
+- [Operações](docs/OPERATIONS.md) - Guia de operações e deploy
+- [Testes](docs/TESTING.md) - Guia de testes
+- [Técnico](docs/TECHNICAL.md) - Documentação técnica
+- [API](docs/API.md) - Documentação da API
+- [Contribuição](docs/CONTRIBUTING.md) - Guia de contribuição
+- [Segurança](docs/SECURITY.md) - Políticas de segurança
+
 ## Funcionalidades
 
 1. **Processamento de Vídeos**


### PR DESCRIPTION
# Docs: Add Documentation Links to README

## Descrição
Este PR adiciona uma seção de Documentação no README principal com links para todos os documentos do projeto.

## Alterações
- Adicionada seção de Documentação no README.md com links para:
  - [Arquitetura](docs/ARCHITECTURE.md)
  - [Desenvolvimento](docs/DEVELOPMENT.md)
  - [Operações](docs/OPERATIONS.md)
  - [Testes](docs/TESTING.md)
  - [Documentação Técnica](docs/TECHNICAL.md)
  - [API](docs/API.md)
  - [Contribuição](docs/CONTRIBUTING.md)
  - [Segurança](docs/SECURITY.md)

## Motivo
A documentação estava disponível mas não era facilmente acessível. Agora todos os documentos estão linkados no README principal, tornando a navegação mais intuitiva e a documentação mais visível.

## Checklist
- [x] Links adicionados ao README
- [x] Todos os documentos estão linkados
- [x] Commit segue o padrão Conventional Commits

## Observações
- Esta alteração melhora a organização e acessibilidade da documentação
- Não há impacto em outras funcionalidades do sistema